### PR TITLE
make new copy of variable to avoid downstream unwanted new values

### DIFF
--- a/src/ibldsp/utils.py
+++ b/src/ibldsp/utils.py
@@ -24,7 +24,7 @@ def sync_timestamps(tsa, tsb, tbin=0.1, return_indices=False, linear=False):
     # determine fixed offset between first timestamp of each series
     # this reduces the size of array for correlation
     offset = tsb[0] - tsa[0]
-    tsa += offset
+    tsa = tsa + offset
 
     def _interp_fcn(tsa, tsb, ib, linear=linear):
         # now compute the bpod/fpga drift and precise time shift
@@ -33,9 +33,10 @@ def sync_timestamps(tsa, tsb, tbin=0.1, return_indices=False, linear=False):
         if linear:
             fcn_a2b = lambda x: (x + offset) * (1 + ab[0]) + ab[1]  # noqa
         else:
-            fcn_a2b = scipy.interpolate.interp1d(
+            interp = scipy.interpolate.interp1d(
                 tsa[ib >= 0], tsb[ib[ib >= 0]], fill_value="extrapolate"
             )
+            fcn_a2b = lambda x: interp(x + offset)
         return fcn_a2b, drift_ppm
 
     # assert sorted inputs

--- a/src/tests/unit/test_ibldsp.py
+++ b/src/tests/unit/test_ibldsp.py
@@ -63,7 +63,7 @@ class TestSyncTimestamps(unittest.TestCase):
         assert np.all(np.isclose(_fcn(tsa[imiss[_ia]]), tsb[imiss2[_ib]]))
 
         # test timestamps with huge offset (previously caused ArrayMemoryError)
-        tsb -= 1e15
+        tsb -= 1e14 # previously 1e-15 but running into rounding issues with float64
         _fcn, _drift = utils.sync_timestamps(tsa, tsb)
         assert np.all(np.isclose(_fcn(tsa), tsb))
 


### PR DESCRIPTION
Changed in place assignment of tsa to explicit assignment during the sync_timestamps as this causing unwanted consequences in trials extraction where the values were changed despite still needing original values. Tests are passing but would be good to have some extra eyes just to double check :) 

@grg2rsr I haven't looked closely but perhaps this may have been the root of the LFP timestamps issues that I remember you were mentioning?