### PR TITLE
Windowgenerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,16 @@
 ## [1.9.0] - Not released 
 
 ### added
-- ibldsp.plots.voltageshow: displays raw data snippets for LFP / AP / CSD with a matplotlib backend
-
+- `ibldsp.plots.voltageshow`: displays raw data snippets for LFP / AP / CSD with a matplotlib backend
+- new methods and documentation for the `ibldsp.util.WindowGenerator`: 
+  - `wg.slice` returns a straight slice to index the window
+  - `wg.slices_valid` returns 3 slices to index the full window, the valid window, and the valid window relative to the full windo
+  - `wg.splice`: splicing add a fade-in / fade-out in the overlap so that reconstruction has unit amplitude
 ### modified
-- ibldsp.voltage.csd: computations in SI to provide current flux in A.m-3 
+- `ibldsp.voltage.csd`: computations in SI to provide current flux in A.m-3 
 
 ### fixed
-- ibldsp.plots.show_channels_labels: noisy channels ambiguity resolved: offending channels are displayed with
+- `ibldsp.plots.show_channels_labels`: noisy channels ambiguity resolved: offending channels are displayed with
 their respective features
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contribution Guide
+
+The main branch is the trunk and features branches are squashed merge after a successful Pull request.
+
+## Contributing a feature
+
+- [X] make sure the tests pass locally
+- [X] use `ruff format` and `ruff check` to make sure the formatting is correct
+- [X] `CHANGELOG.md` documents the changes, references the PR, the date and the new version number in `setup.py`
+- [X] create a PR from your feature branch to main
+
+Reviewer steps for a feature PR
+- [X] the CI passes
+- [X] squash-merge upon a successful review
+
+## Release
+
+- [X] create tag corresponding to the version number `X.Y.Z` on the `main` branch
+
+```shell
+ruff format
+tag=X.Y.Z
+git tag -a $tag 
+git push origin $tag
+```
+
+- [X] Create new release with tag `X.Y.Z` (will automatically publish to PyPI).
+
+```shell 
+gh release create $tag
+```

--- a/README.md
+++ b/README.md
@@ -39,25 +39,4 @@ The following describes the methods implemented in this repository.
 https://doi.org/10.6084/m9.figshare.19705522
 
 ## Contribution
-Contribution checklist:
-- run tests
-- ruff format
-- PR to main
-
-
-Pypi Release checklist:
-- Edit the version number in `setup.py`
-- add release notes in `release_notes.md`
-
-
-```shell
-ruff format
-tag=X.Y.Z
-git tag -a $tag 
-git push origin $tag
-```
-
-Create new release with tag X.Y.Z (will automatically publish to PyPI). Here are command line instructions to do so:
-```shell 
-gh release create $tag
-```
+Please see our [contribution guidelines](CONTRIBUTING.md) for details on how to contribute to this project.

--- a/src/ibldsp/spiketrains.py
+++ b/src/ibldsp/spiketrains.py
@@ -31,9 +31,9 @@ def spikes_venn2(
     """
     assert len(samples_tuple) == 2, "Must have 2 sets of samples."
     assert len(channels_tuple) == 2, "Must have 2 sets of channels."
-    assert all(
-        samples_tuple[i].shape == channels_tuple[i].shape for i in range(2)
-    ), "Samples and channels must match for each sorter."
+    assert all(samples_tuple[i].shape == channels_tuple[i].shape for i in range(2)), (
+        "Samples and channels must match for each sorter."
+    )
 
     num_sorters = 2
     return _spikes_venn(
@@ -76,9 +76,9 @@ def spikes_venn3(
     """
     assert len(samples_tuple) == 3, "Must have 3 sets of samples."
     assert len(channels_tuple) == 3, "Must have 3 sets of channels."
-    assert all(
-        samples_tuple[i].shape == channels_tuple[i].shape for i in range(3)
-    ), "Samples and channels must match for each sorter."
+    assert all(samples_tuple[i].shape == channels_tuple[i].shape for i in range(3)), (
+        "Samples and channels must match for each sorter."
+    )
 
     num_sorters = 3
     return _spikes_venn(

--- a/src/ibldsp/utils.py
+++ b/src/ibldsp/utils.py
@@ -436,12 +436,12 @@ class WindowGenerator(object):
     def slices_valid(self):
         """
         Generator that yields slices for windowed signal processing with valid regions.
-        
+
         This method generates tuples of slice objects that can be used to extract windows
         from a signal and identify the valid (non-overlapping) portions within each window.
         It's particularly useful for reconstruction operations where overlapping regions
         need special handling.
-        
+
         Yields
         ------
         tuple
@@ -449,16 +449,17 @@ class WindowGenerator(object):
             - slice(first, last): The full window slice
             - slice(first_valid, last_valid): The valid portion of the signal in absolute indices
             - slice_window_valid: The valid portion relative to the window (for use within the window)
-        
+
         Notes
         -----
         This generator relies on the firstlast_valid property which provides the
         indices for both the full windows and their valid regions.
         """
         for first, last, first_valid, last_valid in self.firstlast_valid:
-            slice_window_valid = slice(first_valid - first, None if (lv := -(last - last_valid)) == 0 else lv)
+            slice_window_valid = slice(
+                first_valid - first, None if (lv := -(last - last_valid)) == 0 else lv
+            )
             yield slice(first, last), slice(first_valid, last_valid), slice_window_valid
-
 
     def slice_array(self, sig, axis=-1):
         """

--- a/src/ibldsp/utils.py
+++ b/src/ibldsp/utils.py
@@ -268,12 +268,64 @@ def make_channel_index(geom, radius=200.0, pad_val=None):
 
 class WindowGenerator(object):
     """
-    `wg = WindowGenerator(ns, nswin, overlap)`
+    A utility class for generating sliding windows for signal processing applications.
 
-    Provide sliding windows indices generator for signal processing applications.
-    For straightforward spectrogram / periodogram implementation, prefer scipy methods !
+    WindowGenerator provides various methods to iterate through windows of a signal
+    with configurable window size and overlap. It's particularly useful for operations
+    like spectrograms, filtering, or any processing that requires windowed analysis.
 
-    Example of implementations in test_dsp.py.
+    Parameters
+    ----------
+    ns : int
+        Total number of samples in the signal to be windowed.
+    nswin : int
+        Number of samples in each window.
+    overlap : int
+        Number of samples that overlap between consecutive windows.
+
+    Attributes
+    ----------
+    ns : int
+        Total number of samples in the signal.
+    nswin : int
+        Number of samples in each window.
+    overlap : int
+        Number of samples that overlap between consecutive windows.
+    nwin : int
+        Total number of windows.
+    iw : int or None
+        Current window index during iteration.
+
+    Notes
+    -----
+    For straightforward spectrogram or periodogram implementation,
+    scipy methods are recommended over this class.
+
+    Examples
+    --------
+    # straight windowing without overlap
+    >>> wg = WindowGenerator(ns=1000, nwin=111)
+    >>> signal = np.random.randn(1000)
+    >>> for window_slice in wg.slice:
+    ...     window_data = signal[window_slice]
+    ...     # Process window_data
+
+    # windowing with overlap (ie. buffers for apodization)
+    >>> for win_slice, valid_slice, win_valid_slice in wg.slices_valid:
+    ...     window = signal[win_slice]
+    ...     # Process window
+    ...     processed = some_function_with_edge_effect(window)
+    ...     # Only use the valid portion for reconstruction
+    ...     recons[valid_slice] = processed[win_valid_slice]
+
+    # splicing add a fade-in / fade-out in the overlap so that reconstruction has unit amplitude
+    >>> recons = np.zeros_like(signal)
+    >>> for win_slice, amplitude in wg.splice:
+    ...     window = signal[win_slice]
+    ...     # Process window
+    ...     processed = some_function(window)
+    ...     # The processed windows is weighted with the amplitude and added to the reconstructed signal
+    ...     recons[win_slice] = recons[win_slice] + processed * amplitude
     """
 
     def __init__(self, ns, nswin, overlap):
@@ -289,14 +341,35 @@ class WindowGenerator(object):
         self.iw = None
 
     @property
+    def splice(self):
+        """
+        Generator that yields slices and amplitude arrays for windowed signal processing with splicing.
+
+        This property provides a convenient way to iterate through all windows with their
+        corresponding amplitude arrays for proper signal reconstruction. The amplitude arrays
+        contain tapering values (from a Hann window) at the overlapping regions to ensure
+        unit amplitude of all samples of the original signal
+
+        Yields
+        ------
+        tuple
+            A tuple containing:
+            - slice: A Python slice object representing the current window
+            - amp: A numpy array containing amplitude values for proper splicing/tapering
+              at overlap regions
+
+        Notes
+        -----
+        This is particularly useful for overlap-add methods where windows need to be
+        properly weighted before being combined in the reconstruction process.
+        """
+        for first, last, amp in self.firstlast_splicing:
+            yield slice(first, last), amp
+
+    @property
     def firstlast_splicing(self):
         """
-        Generator that yields the indices as well as an amplitude function that can be used
-        to splice the windows together.
-        In the overlap, the amplitude function gradually transitions the amplitude from one window
-        to the next. The amplitudes always sum to one (ie. windows are symmetrical)
-
-        :return: tuple of (first_index, last_index, amplitude_vector]
+        cf. self.splice
         """
         w = scipy.signal.windows.hann((self.overlap + 1) * 2 + 1, sym=True)[
             1 : self.overlap + 1
@@ -323,7 +396,7 @@ class WindowGenerator(object):
             yield (first, last, first_valid, last_valid)
 
     @property
-    def firstlast(self, return_valid=False):
+    def firstlast(self):
         """
         Generator that yields first and last index of windows
 
@@ -343,12 +416,49 @@ class WindowGenerator(object):
     @property
     def slice(self):
         """
-        Generator that yields slices of windows
+        Generator that yields slice objects for each window in the signal.
 
-        :return: a slice of the window
+        This property provides a convenient way to iterate through all windows
+        defined by the WindowGenerator parameters. Each yielded slice can be
+        used directly to index into the original signal array.
+
+        Yields
+        ------
+        slice
+            A Python slice object representing the current window, defined by
+            its first and last indices. The slice can be used to extract the
+            corresponding window from the original signal.
         """
         for first, last in self.firstlast:
             yield slice(first, last)
+
+    @property
+    def slices_valid(self):
+        """
+        Generator that yields slices for windowed signal processing with valid regions.
+        
+        This method generates tuples of slice objects that can be used to extract windows
+        from a signal and identify the valid (non-overlapping) portions within each window.
+        It's particularly useful for reconstruction operations where overlapping regions
+        need special handling.
+        
+        Yields
+        ------
+        tuple
+            A tuple containing three slice objects:
+            - slice(first, last): The full window slice
+            - slice(first_valid, last_valid): The valid portion of the signal in absolute indices
+            - slice_window_valid: The valid portion relative to the window (for use within the window)
+        
+        Notes
+        -----
+        This generator relies on the firstlast_valid property which provides the
+        indices for both the full windows and their valid regions.
+        """
+        for first, last, first_valid, last_valid in self.firstlast_valid:
+            slice_window_valid = slice(first_valid - first, None if (lv := -(last - last_valid)) == 0 else lv)
+            yield slice(first, last), slice(first_valid, last_valid), slice_window_valid
+
 
     def slice_array(self, sig, axis=-1):
         """

--- a/src/ibldsp/waveform_extraction.py
+++ b/src/ibldsp/waveform_extraction.py
@@ -66,9 +66,9 @@ def extract_wfs_array(
 
     # check that the spike window is included in the recording:
     last_idx = df["sample"].iloc[-1]
-    assert (
-        last_idx + (spike_length_samples - trough_offset) < arr.shape[1]
-    ), f"Spike index {last_idx} extends past end of recording ({arr.shape[1]} samples)."
+    assert last_idx + (spike_length_samples - trough_offset) < arr.shape[1], (
+        f"Spike index {last_idx} extends past end of recording ({arr.shape[1]} samples)."
+    )
 
     nwf = len(df)
 
@@ -596,9 +596,9 @@ class WaveformsLoader:
             indices = (
                 np.tile(indices, (labels.size, 1)) if indices.ndim < 2 else indices
             )
-            assert (
-                indices.shape[0] == labels.size
-            ), "If indices is a 2D-array, the second dimension must match the number of clusters."
+            assert indices.shape[0] == labels.size, (
+                "If indices is a 2D-array, the second dimension must match the number of clusters."
+            )
             _, iu, _ = np.intersect1d(
                 self.df_clusters.index, labels, return_indices=True
             )
@@ -656,9 +656,9 @@ class WaveformsLoader:
             else:
                 labels = rg.choice(self.labels, num_random_labels, replace=False)
         else:
-            assert (
-                num_random_labels is None
-            ), "labels and num_random_labels cannot both be set"
+            assert num_random_labels is None, (
+                "labels and num_random_labels cannot both be set"
+            )
 
         labels = np.array(labels)
         label_idx = np.array([np.where(self.labels == label)[0][0] for label in labels])

--- a/src/neuropixel.py
+++ b/src/neuropixel.py
@@ -288,17 +288,17 @@ class NP2Converter:
         self.ratio = int(self.fs_ap / self.fs_lf)
         self.nsamples = nsamples or self.sr.ns
         self.samples_window = nwindow or 2 * self.fs_ap
-        assert (
-            np.mod(self.samples_window, self.ratio) == 0
-        ), f"nwindow must be a factor or {self.ratio}"
+        assert np.mod(self.samples_window, self.ratio) == 0, (
+            f"nwindow must be a factor or {self.ratio}"
+        )
         self.samples_overlap = 576
-        assert (
-            np.mod(self.samples_overlap, self.ratio) == 0
-        ), f"samples_overlap must be a factor or {self.ratio}"
+        assert np.mod(self.samples_overlap, self.ratio) == 0, (
+            f"samples_overlap must be a factor or {self.ratio}"
+        )
         self.samples_taper = int(self.samples_overlap / 4)
-        assert (
-            np.mod(self.samples_taper, self.ratio) == 0
-        ), f"samples_taper must be a factor or {self.ratio}"
+        assert np.mod(self.samples_taper, self.ratio) == 0, (
+            f"samples_taper must be a factor or {self.ratio}"
+        )
         self.taper = np.r_[
             0, scipy.signal.windows.cosine((self.samples_taper - 1) * 2), 0
         ]
@@ -574,9 +574,9 @@ class NP2Converter:
                     chunk[:, self.shank_info[sh]["chns"]] = srs[first:last, :]
                 else:
                     chunk[:, self.shank_info[sh]["chns"][:-1]] = srs[first:last, :-1]
-            assert np.array_equal(
-                expected, chunk
-            ), "data in original file and split files do no match"
+            assert np.array_equal(expected, chunk), (
+                "data in original file and split files do no match"
+            )
 
         # close the sglx instances once we are done checking
         for sh in self.shank_info.keys():

--- a/src/tests/unit/test_ibldsp.py
+++ b/src/tests/unit/test_ibldsp.py
@@ -368,6 +368,13 @@ class TestWindowGenerator(unittest.TestCase):
         for first, last, amp in wg.firstlast_splicing:
             sig_out[first:last] = sig_out[first:last] + amp * sig_in[first:last]
         np.testing.assert_allclose(sig_out, sig_in)
+        # now performs the same operation with the new interface
+        sig_in = np.random.randn(600)
+        sig_out = np.zeros_like(sig_in)
+        wg = utils.WindowGenerator(ns=600, nswin=100, overlap=20)
+        for slicewin, amp in wg.splice:
+            sig_out[slicewin] = sig_out[slicewin] + amp * sig_in[slicewin]
+        np.testing.assert_allclose(sig_out, sig_in)
 
     def test_firstlast_valid(self):
         sig_in = np.random.randn(600)
@@ -375,6 +382,15 @@ class TestWindowGenerator(unittest.TestCase):
         wg = utils.WindowGenerator(ns=600, nswin=100, overlap=20)
         for first, last, first_valid, last_valid in wg.firstlast_valid:
             sig_out[first_valid:last_valid] = sig_in[first_valid:last_valid]
+        np.testing.assert_array_equal(sig_out, sig_in)
+
+    def test_slices_valid(self):
+        sig_in = np.random.randn(600)
+        sig_out = np.zeros_like(sig_in)
+        wg = utils.WindowGenerator(ns=600, nswin=39, overlap=20)
+        for slice_win, slice_valid, slice_win_valid in wg.slices_valid:
+            win = sig_in[slice_win]
+            sig_out[slice_valid] = win[slice_win_valid]
         np.testing.assert_array_equal(sig_out, sig_in)
 
     def test_tscale(self):


### PR DESCRIPTION
- new methods and documentation for the `ibldsp.util.WindowGenerator`: 
  - `wg.slice` returns a straight slice to index the window
  - `wg.slices_valid` returns 3 slices to index the full window, the valid window, and the valid window relative to the full windo
  - `wg.splice`: splicing add a fade-in / fade-out in the overlap so that reconstruction has unit amplitude