### PR TITLE
add spikeglx.spikeinterface_recording and spikeinterface dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.11.0] - 2026-06-01
+
+### added
+- `spikeglx.spikeinterface_recording`: load a SpikeGLX AP recording from a `.cbin` or `.bin` file, returning a SpikeInterface `BaseRecording`
+- `spikeinterface` added to dependencies
+
 ## [1.10.0] - 2026-02-05
 
 ### added

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpy >= 1.21.6
 ONE-api >= 2.11.0
 pandas
 scipy >= 1.11
+spikeinterface

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt") as f:
 
 setuptools.setup(
     name="ibl-neuropixel",
-    version="1.10.0",
+    version="1.11.0",
     author="The International Brain Laboratory",
     description="Collection of tools for Neuropixel 1.0 and 2.0 probes data",
     long_description=long_description,

--- a/src/spikeglx.py
+++ b/src/spikeglx.py
@@ -13,6 +13,8 @@ from iblutil.util import Bunch
 import one.alf.path
 
 import neuropixel
+import spikeinterface.extractors as se
+from spikeinterface.extractors.extractor_classes import SpikeGLXRecordingExtractor
 
 
 SAMPLE_SIZE = 2  # int16
@@ -1123,3 +1125,27 @@ def get_sync_map(folder_ephys):
         return None
     else:
         return _sync_map_from_hardware_config(hc)
+
+
+def spikeinterface_recording(file_path: Path):
+    """Load a SpikeGLX AP recording from a .cbin or .bin file.
+
+    Parameters
+    ----------
+    file_path : Path
+        Path to a compressed `.ap.cbin` or uncompressed `.ap.bin` file.
+
+    Returns
+    -------
+    spikeinterface.core.BaseRecording
+        SpikeInterface recording loaded with the appropriate extractor.
+    """
+    file_path = Path(file_path)
+    folder_path = file_path.parent
+    if file_path.suffix == ".cbin":
+        return se.read_cbin_ibl(
+            folder_path=folder_path, cbin_file_path=file_path, stream_name="ap"
+        )
+    stream_names, _ = SpikeGLXRecordingExtractor.get_streams(folder_path=folder_path)
+    ap_stream = next(s for s in stream_names if s.endswith(".ap"))
+    return se.read_spikeglx(folder_path=folder_path, stream_name=ap_stream)

--- a/src/tests/unit/test_spikeglx.py
+++ b/src/tests/unit/test_spikeglx.py
@@ -6,6 +6,7 @@ import uuid
 
 import numpy as np
 from iblutil.io import hashfile
+import spikeinterface.core as si
 
 import neuropixel
 import spikeglx
@@ -809,3 +810,36 @@ class TestOnlineSpikeGlxReader(unittest.TestCase):
             sr = spikeglx.OnlineReader(file_ap)
             # just try to read the last sample of the bunch
             assert np.all(sr[299_999, :] == 0)
+
+
+class TestSpikeinterfaceRecording(unittest.TestCase):
+    """Tests for spikeinterface_recording() with .bin and .cbin inputs."""
+
+    META_FILE = TEST_PATH / "sample3B_g0_t0.imec1.ap.meta"
+    NS = 3000
+    NC = 385
+
+    def setUp(self):
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.workdir = Path(self._tempdir.name)
+        self._bin_file = spikeglx._mock_spikeglx_file(
+            self.workdir / "sample3B_g0_t0.imec1.ap.bin",
+            self.META_FILE,
+            ns=self.NS,
+            nc=self.NC,
+        )["bin_file"]
+
+    def tearDown(self):
+        self._tempdir.cleanup()
+
+    def test_bin(self):
+        rec = spikeglx.spikeinterface_recording(self._bin_file)
+        self.assertIsInstance(rec, si.BaseRecording)
+        self.assertAlmostEqual(rec.get_sampling_frequency(), 30000, delta=1)
+
+    def test_cbin(self):
+        with spikeglx.Reader(self._bin_file) as sr:
+            cbin_file = sr.compress_file()
+        rec = spikeglx.spikeinterface_recording(cbin_file)
+        self.assertIsInstance(rec, si.BaseRecording)
+        self.assertAlmostEqual(rec.get_sampling_frequency(), 30000, delta=1)


### PR DESCRIPTION
## Summary
- Adds `spikeglx.spikeinterface_recording(file_path)`: loads a SpikeGLX AP recording from a `.cbin` (via `read_cbin_ibl`) or `.bin` (via `read_spikeglx`) file and returns a SpikeInterface `BaseRecording`
- Adds `spikeinterface` to `requirements.txt`
- Unit tests for both `.bin` and `.cbin` cases using existing mock fixtures
- Version bumped to `1.11.0`

## Test plan
- [x] `pytest ./src/tests/unit` — 115/115 passed
- [x] `ruff format` and `ruff check` — clean