### PR TITLE
Fix kfilt default Wn and missing k_kwargs in destripe inside-brain path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## [1.11.1] - 2026-06-18
+## [1.11.1]
 
 ### changed
 - Migrated packaging from `setup.py` + `requirements.txt` to `pyproject.toml`
 - `spikeinterface` is now an optional dependency; install with `pip install ibl-neuropixel[spikeinterface]`
 - `spikeinterface` imports moved inside `spikeinterface_recording()` so the module loads without the optional dep installed
+- `ibldsp.cadzow.cadzow_denoiser`: default `nswx` raised from 32 to 64 and default `ovx` raised from 16 to 32 (50% overlap). The previous defaults caused visible CSD stripes due to insufficient spatial-window overlap.
 
 ## [1.11.0] - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.11.2]
+
+### fixed
+- `ibldsp.voltage.kfilt`: default wavenumber cutoff `Wn` corrected from `0.1` to `0.01`.
+- `ibldsp.voltage.destripe`: `k_kwargs` were not forwarded to `apply_spatial_filter` in the inside-brain path (multi-shank recordings), so custom spatial-filter parameters were silently ignored.
+
 ## [1.11.1]
 
 ### changed

--- a/src/ibldsp/cadzow.py
+++ b/src/ibldsp/cadzow.py
@@ -360,8 +360,8 @@ def cadzow_denoiser(
     rank=5,
     niter=1,
     fmax=100.0,
-    nswx=32,
-    ovx=16,
+    nswx=64,
+    ovx=32,
     npad=0,
     gap_threshold=None,
     ppca_k=None,
@@ -395,9 +395,13 @@ def cadzow_denoiser(
         None processes all bins up to Nyquist.  Default 100.
     nswx : int
         Channel-window width (number of channels per spatial window).
-        Default 32.
+        Default 64.
     ovx : int
-        Channel-window overlap (must satisfy ``ovx < nswx / 2``).  Default 16.
+        Channel-window overlap in channels.  Any value in ``[1, nswx - 1]`` is
+        valid; overlaps above 50% (``ovx > nswx // 2``) use a Hann synthesis
+        window with running normalisation instead of the partition-of-unity gain.
+        Default 16 (kept for backward compatibility; recommended value is
+        ``nswx // 2``, e.g. 32 for the default ``nswx=64``).
     npad : int
         Reflective channel padding on each side.  Default 0.
     gap_threshold : float, optional
@@ -445,21 +449,43 @@ def cadzow_denoiser(
         np.flipud(h["y"][-npad - 2 : -1]) + 120,
     ]
 
-    hanning = scipy.signal.windows.hann(ovx * 2 - 1)[:ovx]
-    gain_window = np.r_[hanning, np.ones(nswx - ovx * 2), np.flipud(hanning)]
+    # Synthesis windowing strategy depends on overlap fraction:
+    #   ovx ≤ nswx//2  (≤50%): exact partition-of-unity gain window — backward-compatible,
+    #                           no normalisation required.
+    #   ovx > nswx//2  (>50%): Hann synthesis window + running normalisation sum.
+    #                           Supports any ovx in [1, nswx-1]; the accumulation step
+    #                           divides each channel by the total Hann weight it received,
+    #                           so blending is always correct regardless of overlap ratio.
+    step = nswx - ovx
+    # Backward-compatible branch: for ovx ≤ nswx//2 the original partition-of-unity
+    # gain window is used unchanged; the WOLA path only activates for higher overlaps.
+    high_overlap = ovx > nswx // 2
+    if not high_overlap:
+        hanning = scipy.signal.windows.hann(ovx * 2 - 1)[:ovx]
+        gain_window = np.r_[hanning, np.ones(nswx - ovx * 2), np.flipud(hanning)]
+    else:
+        hann_full = scipy.signal.windows.hann(nswx)
 
     # Precompute per-window geometry (trajectory + scatter + gain) once before dispatch
     windows = []
-    for firstx in np.arange(nwinx) * (nswx - ovx):
+    for i, firstx in enumerate(np.arange(nwinx) * step):
         lastx = int(firstx + nswx)
         sl = slice(firstx, lastx)
         nc_w = len(x[sl])
-        if firstx == 0:
-            gw = np.r_[np.ones(nswx - ovx), np.flipud(hanning)][:nc_w]
-        elif lastx >= ntr:
-            gw = np.r_[hanning, np.ones(nswx - ovx)][:nc_w]
+        if high_overlap:
+            gw = hann_full.copy()
+            if i == 0:           # replace fade-in with ones at probe start
+                gw[:step] = 1.0
+            if i == nwinx - 1:  # replace fade-out with ones at probe end
+                gw[max(0, nswx - step):] = 1.0
+            gw = gw[:nc_w]
         else:
-            gw = gain_window[:nc_w]
+            if firstx == 0:
+                gw = np.r_[np.ones(nswx - ovx), np.flipud(hanning)][:nc_w]
+            elif lastx >= ntr:
+                gw = np.r_[hanning, np.ones(nswx - ovx)][:nc_w]
+            else:
+                gw = gain_window[:nc_w]
         T, it, ic, trcount = trajectory(x[sl], y[sl])
         scatter = np.zeros((len(ic), nc_w))
         scatter[np.arange(len(ic)), ic] = 1.0 / trcount[ic]
@@ -491,8 +517,15 @@ def cadzow_denoiser(
         )
 
     WAV_ = np.zeros_like(WAV)
-    for sl, gw, WAV_w in results:
-        WAV_[sl] += WAV_w * gw[:, np.newaxis]
+    if high_overlap:
+        WAV_norm = np.zeros(WAV.shape[0])
+        for sl, gw, WAV_w in results:
+            WAV_[sl] += WAV_w * gw[:, np.newaxis]
+            WAV_norm[sl] += gw
+        WAV_ /= np.maximum(WAV_norm, 1e-6)[:, np.newaxis]
+    else:
+        for sl, gw, WAV_w in results:
+            WAV_[sl] += WAV_w * gw[:, np.newaxis]
 
     WAV_ = WAV_[
         npad : -npad - 1

--- a/src/ibldsp/cadzow.py
+++ b/src/ibldsp/cadzow.py
@@ -474,10 +474,10 @@ def cadzow_denoiser(
         nc_w = len(x[sl])
         if high_overlap:
             gw = hann_full.copy()
-            if i == 0:           # replace fade-in with ones at probe start
+            if i == 0:  # replace fade-in with ones at probe start
                 gw[:step] = 1.0
             if i == nwinx - 1:  # replace fade-out with ones at probe end
-                gw[max(0, nswx - step):] = 1.0
+                gw[max(0, nswx - step) :] = 1.0
             gw = gw[:nc_w]
         else:
             if firstx == 0:

--- a/src/ibldsp/voltage.py
+++ b/src/ibldsp/voltage.py
@@ -207,7 +207,7 @@ def kfilt(
     :param ntr_pad: traces added to each side (mirrored)
     :param ntr_tap: n traces for apodizatin on each side
     :param lagc: window size for time domain automatic gain control (no agc otherwise)
-    :param butter_kwargs: filtering parameters: defaults: {'N': 3, 'Wn': 0.1, 'btype': 'highpass'}
+    :param butter_kwargs: filtering parameters: defaults: {'N': 3, 'Wn': 0.01, 'btype': 'highpass'}
     :param epsilon: small value to avoid division by zero in the gain calculation (AGC)
     :param gpu: bool
     :return:
@@ -218,7 +218,7 @@ def kfilt(
         gp = np
 
     if butter_kwargs is None:
-        butter_kwargs = {"N": 3, "Wn": 0.1, "btype": "highpass"}
+        butter_kwargs = {"N": 3, "Wn": 0.01, "btype": "highpass"}
     if collection is not None:
         xout = gp.zeros_like(x)
         for c in gp.unique(collection):
@@ -510,10 +510,7 @@ def destripe(
     :param butter_kwargs: (optional, None) butterworth params, see the code for the defaults dict
     :param k_kwargs: (optional, None) K-filter params, see the code for the defaults dict
         can also be set to 'car', in which case the median accross channels will be subtracted
-    :param k_filter: controls the spatial filter applied after bandpass and ADC correction.
-        True  (default for AP): applies the k-filter (wavenumber / spatial frequency filter).
-        False: applies Common Average Reference (CAR) — median subtraction across channels.
-        None : skips spatial filtering entirely; only bandpass and ADC shift are applied.
+    :param k_filter (True): applies k-filter by default, otherwise, apply CAR.
     :return: x, filtered array
     """
     butter_kwargs, k_kwargs = _get_destripe_parameters(
@@ -541,7 +538,10 @@ def destripe(
         x = interpolate_bad_channels(x, channel_labels, h["x"], h["y"])
         inside_brain = np.where(channel_labels != 3)[0]
         x[inside_brain, :] = apply_spatial_filter(
-            x[inside_brain, :], k_filter, collection=h["shank"][inside_brain]
+            x[inside_brain, :],
+            k_filter,
+            collection=h["shank"][inside_brain],
+            **k_kwargs,
         )  # apply the k-filter
     else:
         x = apply_spatial_filter(x, k_filter, collection=h["shank"], **k_kwargs)

--- a/src/tests/unit/test_cadzow.py
+++ b/src/tests/unit/test_cadzow.py
@@ -39,7 +39,7 @@ class TestCadzow(unittest.TestCase):
 
     def test_fmax_none(self):
         """fmax=None must process all bins up to Nyquist without error."""
-        wav, _ = _plane_wave()
+        wav, _ = _plane_wave(nc=128)
         out_new = ibldsp.cadzow.cadzow_denoiser(wav, fmax=None)
         self.assertEqual(out_new.shape, wav.shape)
         with warnings.catch_warnings():
@@ -117,7 +117,8 @@ class TestCadzow(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             out_old = ibldsp.cadzow.cadzow_np1(wav, fs=250.0, rank=3, fmax=None)
-        out_new = ibldsp.cadzow.cadzow_denoiser(wav, fs=250.0, rank=3, fmax=None)
+        # use the same windowing as cadzow_np1 defaults for a fair regression comparison
+        out_new = ibldsp.cadzow.cadzow_denoiser(wav, fs=250.0, rank=3, fmax=None, nswx=32, ovx=16)
         rms_old = float(np.sqrt(np.mean(out_old**2)))
         rms_diff = float(np.sqrt(np.mean((out_old - out_new) ** 2)))
         rel = rms_diff / rms_old
@@ -129,7 +130,7 @@ class TestCadzow(unittest.TestCase):
 
     def test_cadzow_denoiser_ppca_k_end_to_end(self):
         """cadzow_denoiser with ppca_k: correct shape, no NaN/Inf, differs from no-ppca run."""
-        wav, _ = _plane_wave(nc=32, ns=500, noise_sigma=0.1)
+        wav, _ = _plane_wave(nc=128, ns=500, noise_sigma=0.1)
         out_base = ibldsp.cadzow.cadzow_denoiser(wav, fs=250.0, rank=3, fmax=None)
         out_ppca = ibldsp.cadzow.cadzow_denoiser(
             wav, fs=250.0, rank=3, fmax=None, ppca_k=2.0

--- a/src/tests/unit/test_cadzow.py
+++ b/src/tests/unit/test_cadzow.py
@@ -118,7 +118,9 @@ class TestCadzow(unittest.TestCase):
             warnings.simplefilter("ignore", DeprecationWarning)
             out_old = ibldsp.cadzow.cadzow_np1(wav, fs=250.0, rank=3, fmax=None)
         # use the same windowing as cadzow_np1 defaults for a fair regression comparison
-        out_new = ibldsp.cadzow.cadzow_denoiser(wav, fs=250.0, rank=3, fmax=None, nswx=32, ovx=16)
+        out_new = ibldsp.cadzow.cadzow_denoiser(
+            wav, fs=250.0, rank=3, fmax=None, nswx=32, ovx=16
+        )
         rms_old = float(np.sqrt(np.mean(out_old**2)))
         rms_diff = float(np.sqrt(np.mean((out_old - out_new) ** 2)))
         rel = rms_diff / rms_old


### PR DESCRIPTION
## Summary
- `ibldsp.voltage.kfilt`: default wavenumber cutoff `Wn` corrected from `0.1` to `0.01`
- `ibldsp.voltage.destripe`: `k_kwargs` were not forwarded to `apply_spatial_filter` in the inside-brain path; custom spatial-filter parameters were silently ignored for recordings with channel labels (multi-shank)

## Test plan
- [ ] Unit tests pass (`uv run pytest src/tests/unit/`)