### PR TITLE
Re-interpolate bad channels after Cadzow to fix CSD stripe artifacts

### DIFF
--- a/src/ibldsp/voltage.py
+++ b/src/ibldsp/voltage.py
@@ -411,7 +411,14 @@ def saturation_cbin(
 
 
 def interpolate_bad_channels(
-    data, channel_labels=None, x=None, y=None, p=1.3, kriging_distance_um=20, gpu=False
+    data,
+    channel_labels=None,
+    x=None,
+    y=None,
+    p=1.3,
+    kriging_distance_um=20,
+    gpu=False,
+    groupby_y=False,
 ):
     """
     Interpolate the channel labeled as bad channels using linear interpolation.
@@ -423,6 +430,14 @@ def interpolate_bad_channels(
     :param p:
     :param kriging_distance_um:
     :param gpu: bool
+    :param groupby_y: bool. When True, each bad channel is exactly linearly interpolated
+        between its nearest good neighbours *above* and *below* within its own column
+        (same x-coordinate), skipping over any other bad channels in between, instead of
+        using the exponential-decay kriging weights below. This collapses to a 1-D
+        interpolation along y per column, which is what exactly cancels a per-column
+        second-difference such as ``current_source_density``'s — the kriging weights are
+        tuned for the 2-D multi-column neighbourhood and cannot do this exactly regardless
+        of ``kriging_distance_um``.
     :return:
     """
     if gpu:
@@ -435,17 +450,42 @@ def interpolate_bad_channels(
 
     # we interpolate only noisy channels or dead channels (0: good), out of the brain channels are left
     bad_channels = gp.where(np.logical_or(channel_labels == 1, channel_labels == 2))[0]
+    if groupby_y:
+        for i in bad_channels:
+            good_same_col = np.setdiff1d(
+                np.where(x == x[i])[0], bad_channels, assume_unique=True
+            )
+            dy = y[good_same_col] - y[i]
+            below, above = good_same_col[dy <= 0], good_same_col[dy >= 0]
+            lo = below[np.argmax(y[below])] if below.size else None
+            hi = above[np.argmin(y[above])] if above.size else None
+            if lo is None and hi is None:
+                data[i, :] = 0
+            elif lo is None:
+                data[i, :] = data[hi, :]
+            elif hi is None:
+                data[i, :] = data[lo, :]
+            else:
+                d_lo, d_hi = y[i] - y[lo], y[hi] - y[i]
+                if d_lo + d_hi == 0:
+                    data[i, :] = data[lo, :]
+                else:
+                    data[i, :] = (data[lo, :] * d_hi + data[hi, :] * d_lo) / (
+                        d_lo + d_hi
+                    )
+        return data
     for i in bad_channels:
         # compute the weights to apply to neighbouring traces
         offset = gp.abs(x - x[i] + 1j * (y - y[i]))
         weights = gp.exp(-((offset / kriging_distance_um) ** p))
         weights[bad_channels] = 0
         weights[weights < 0.005] = 0
-        weights = weights / gp.sum(weights)
-        imult = gp.where(weights > 0.005)[0]
-        if imult.size == 0:
+        wsum = gp.sum(weights)
+        if wsum == 0:
             data[i, :] = 0
             continue
+        weights = weights / wsum
+        imult = gp.where(weights > 0.005)[0]
         data[i, :] = gp.matmul(weights[imult], data[imult, :])
     # from viewephys.gui import viewephys
     # f = viewephys(data.T, fs=1/30, h=h, title='interp2')
@@ -1199,6 +1239,13 @@ def _resample_lfp_chunk(args):
             fs=fs / q,
             **{**cadzow_kwargs, "n_jobs": 1},
         )
+        # Cadzow re-estimates every channel from its own rank-reduced spatial fit,
+        # including already-interpolated bad channels — this can reintroduce a small
+        # per-channel amplitude mismatch that current_source_density's per-column
+        # second-difference turns into a spurious horizontal line. Re-interpolate those
+        # channels from their Cadzow-denoised same-column neighbours to remove it.
+        if channel_labels is not None:
+            dec = interpolate_bad_channels(dec, channel_labels, cx, cy, groupby_y=True)
 
     n_out = last_out - first_out
     valid = dec[:, pad_left_out : pad_left_out + n_out]

--- a/src/tests/unit/test_voltage.py
+++ b/src/tests/unit/test_voltage.py
@@ -159,6 +159,75 @@ class TestSaturation(unittest.TestCase):
         self.assertEqual(81, np.sum(df_sat["stop_sample"] - df_sat["start_sample"]))
 
 
+class TestInterpolateBadChannels(unittest.TestCase):
+    """groupby_y=True: exact per-column linear interpolation along y, ignoring
+    geometrically-closer cross-column neighbours. Motivated by current_source_density,
+    which differentiates each column independently and is disrupted by a channel filled
+    in from a different column's trend."""
+
+    def setUp(self):
+        self.h = neuropixel.trace_header(version=1)
+        self.nc = self.h["x"].size
+        self.x, self.y = self.h["x"], self.h["y"]
+        # a function that is linear in y: exact two-point linear interpolation must
+        # reproduce it exactly at any interior missing sample.
+        f = 3.0 * self.y + 7.0
+        self.data = np.tile(f[:, np.newaxis], (1, 5)).astype(np.float64)
+
+    def test_isolated_bad_channel_exact_recovery(self):
+        labels = np.zeros(self.nc, dtype=int)
+        labels[193] = 1
+        out = ibldsp.voltage.interpolate_bad_channels(
+            self.data.copy(), labels, self.x, self.y, groupby_y=True
+        )
+        np.testing.assert_allclose(out[193], self.data[193])
+
+    def test_adjacent_same_column_bad_channels_exact_recovery(self):
+        # 250 and 254 are adjacent within the same column (x[250] == x[254]).
+        assert self.x[250] == self.x[254]
+        labels = np.zeros(self.nc, dtype=int)
+        labels[[250, 254]] = 1
+        out = ibldsp.voltage.interpolate_bad_channels(
+            self.data.copy(), labels, self.x, self.y, groupby_y=True
+        )
+        np.testing.assert_allclose(out[[250, 254]], self.data[[250, 254]])
+
+    def test_ignores_closer_cross_column_neighbour(self):
+        # channel 191 is geometrically closer to 193 than 193's same-column
+        # neighbours (189, 195, 197) are - groupby_y=True must not use it.
+        labels = np.zeros(self.nc, dtype=int)
+        labels[193] = 1
+        corrupted = self.data.copy()
+        corrupted[191] = 1e6  # would dominate a distance-weighted kriging fit
+        out = ibldsp.voltage.interpolate_bad_channels(
+            corrupted, labels, self.x, self.y, groupby_y=True
+        )
+        np.testing.assert_allclose(out[193], self.data[193])
+
+    def test_edge_channel_falls_back_to_single_neighbour(self):
+        # the top-most channel of a column has no neighbour above it.
+        col0 = np.where(self.x == self.x[0])[0]
+        top = col0[np.argmin(self.y[col0])]
+        below = col0[self.y[col0] == np.sort(self.y[col0])[1]][0]
+        labels = np.zeros(self.nc, dtype=int)
+        labels[top] = 1
+        out = ibldsp.voltage.interpolate_bad_channels(
+            self.data.copy(), labels, self.x, self.y, groupby_y=True
+        )
+        np.testing.assert_allclose(out[top], self.data[below])
+
+    def test_default_kriging_path_unaffected(self):
+        # groupby_y defaults to False: behaviour must match the original
+        # multi-column kriging interpolation, including the all-neighbours-bad
+        # fallback to zero (previously reached via a NaN division, now explicit).
+        labels = np.zeros(self.nc, dtype=int)
+        labels[:5] = 1  # first few channels: neighbours within range are also bad
+        out = ibldsp.voltage.interpolate_bad_channels(
+            self.data.copy(), labels, self.x, self.y
+        )
+        self.assertTrue(np.all(np.isfinite(out)))
+
+
 class TestLFP(unittest.TestCase):
     def test_rsamp_cbin(self):
         """
@@ -195,6 +264,46 @@ class TestLFP(unittest.TestCase):
             za = spikeglx.Reader(out_file, ns=ns // 5, nc=nc, fs=500, dtype=np.float32)
             diff = d[0:-1:resamp_factor_q, :] - za[:]
             np.testing.assert_array_less(np.abs(diff[1024:-1024] / 1000), 1e-3)
+
+    def test_rsamp_cbin_cadzow_reinterpolation(self):
+        """channel_labels + cadzow_kwargs together: the bad channels Cadzow re-estimates
+        must be overwritten by an exact per-column linear interpolation of their
+        Cadzow-denoised neighbours, so the pipeline output is a fixed point of
+        interpolate_bad_channels(groupby_y=True)."""
+        ns, nc, fs = int(10 * 2500), 16, 2500
+        with tempfile.TemporaryDirectory() as temp_dir:
+            testfile = Path(temp_dir).joinpath("test.dat")
+            out_file = Path(temp_dir).joinpath("test_rs.npy")
+            d = np.zeros((ns, nc), dtype=np.float32)
+            for ic in range(nc):
+                d[:, ic] = np.sin(2 * np.pi * (10 + ic * 4) * np.arange(ns) / fs) * 1000
+            d.tofile(testfile)
+
+            sr = spikeglx.Reader(testfile, ns=ns, nc=nc, fs=fs, dtype=np.float32)
+            h = neuropixel.trace_header(version=1)
+            x, y = h["x"][:nc], h["y"][:nc]
+            self.assertEqual(x[4], x[8])  # 4 & 8 adjacent within the same column
+            channel_labels = np.zeros(nc, dtype=int)
+            channel_labels[[4, 8, 9]] = 1
+
+            ibldsp.voltage.resample_denoise_lfp_cbin(
+                sr,
+                output=out_file,
+                dtype=np.float32,
+                highpass_cutoff=None,
+                car=False,
+                channel_labels=channel_labels,
+                cadzow_kwargs=dict(rank=3, fmax=None, nswx=8, ovx=4),
+            )
+            za = spikeglx.Reader(
+                out_file, ns=ns // 5, nc=nc, fs=fs / 5, dtype=np.float32
+            )
+            out = za[:].T.astype(np.float64)
+            self.assertTrue(np.all(np.isfinite(out)))
+            fixed_point = ibldsp.voltage.interpolate_bad_channels(
+                out.copy(), channel_labels, x, y, groupby_y=True
+            )
+            np.testing.assert_allclose(out, fixed_point, rtol=1e-6)
 
 
 class TestDetectBadChannels(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `cadzow_denoiser` re-estimates every channel from its own rank-reduced spatial fit, including channels already fixed by `interpolate_bad_channels` upstream. This reintroduces a small per-channel amplitude mismatch that `current_source_density`'s per-column second difference turns into spurious horizontal stripes.
- Add `interpolate_bad_channels(groupby_y=True)`: exact 1-D linear interpolation along y within a channel's own column (skipping other bad channels), instead of the existing 2-D kriging weights — which favour physically closer cross-column channels over the same-column depth-neighbours that `current_source_density` actually differentiates against, and can't cancel the artifact regardless of `kriging_distance_um`.
- Call it in `_resample_lfp_chunk` right after `cadzow_denoiser`, for LFP-band processing only (when `cadzow_kwargs` is set).
- Drive-by fix: the existing kriging path divided by zero before checking for it when all in-range neighbours are also flagged bad; now falls back to zero cleanly without a spurious `RuntimeWarning`.
- No change to any other caller of `interpolate_bad_channels` (AP-band destriping, waveform extraction, GPU destriping) — they don't pass `groupby_y`, so they keep the original behaviour exactly.

## Test plan
- [x] `pytest src/tests/unit/test_voltage.py src/tests/unit/test_cadzow.py` — 24 passed
- [x] New `TestInterpolateBadChannels`: isolated bad channel exact recovery, adjacent same-column pair, ignores closer cross-column neighbour, edge-channel fallback, default kriging path regression
- [x] New `TestLFP::test_rsamp_cbin_cadzow_reinterpolation`: end-to-end check that `resample_denoise_lfp_cbin` output is a fixed point of `interpolate_bad_channels(groupby_y=True)`
- [x] `ruff check` / `ruff format --check` clean