### PR TITLE
LFP saturation muting, amplitude-only detection, and boundary apodization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # repo specific stuff
 src/tests/fixtures/np2split/*.*bin*
 
+# Mac
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/ibldsp/voltage.py
+++ b/src/ibldsp/voltage.py
@@ -1189,12 +1189,24 @@ def _resample_lfp_chunk(args):
         car,
         car_file,
         cadzow_kwargs,
+        saturation_file,
+        mute_window_samples,
     ) = args
 
     out_dtype = np.dtype(out_dtype_str)
     # reader_kwargs supplies nc/ns/fs/dtype for files that have no .meta (e.g. unit tests).
     sr_local = spikeglx.Reader(file_bin, **reader_kwargs)
     raw = sr_local[first_in:last_in, :nc].T.astype(np.float32)  # (nc, L_in)
+
+    # Mute saturated stretches before any filtering so rail-clipped values never enter the
+    # highpass or anti-alias FIR. The cosine taper is rebuilt here from the input-rate
+    # boolean mask (see ibldsp.voltage.saturation) to avoid pickling a full-length array.
+    if saturation_file is not None:
+        sat = np.load(saturation_file, mmap_mode="r")
+        sat_slice = np.asarray(sat[first_in:last_in], dtype=np.float64)
+        win = scipy.signal.windows.cosine(mute_window_samples)
+        mute = np.maximum(0.0, 1.0 - scipy.signal.convolve(sat_slice, win, mode="same"))
+        raw = raw * mute[np.newaxis, :].astype(np.float32)
 
     if major_version == 1:
         raw = fourier.fshift(raw, sample_shift, axis=1)
@@ -1278,6 +1290,8 @@ def resample_denoise_lfp_cbin(
     n_jobs: int = 1,
     car: bool = True,
     cadzow_kwargs: dict | None = None,
+    saturation_file: Path | None = None,
+    mute_window_samples: int = 7,
 ) -> Path:
     """
     Resample and denoise local field potential (LFP) data from a SpikeGLX binary file.
@@ -1312,6 +1326,16 @@ def resample_denoise_lfp_cbin(
         inside each worker; outer-level parallelism is controlled by *n_jobs* above.
         The chunk window (CHUNK_SIZE_OUT + 2 × PAD_OUT = 9216) is a multiple of the
         canonical Cadzow FFT window (256 × 3 = 768) by design.  Default None (disabled).
+    saturation_file : Path or None
+        Path to a ``(ns,)`` boolean ``.npy`` memmap flagging saturated samples at the
+        input rate.  When provided, each worker rebuilds a cosine mute taper from its
+        input slice and multiplies the raw traces by it before any processing, so
+        saturated (rail-clipped) values never enter the highpass or anti-alias filters.
+        Default None (no muting).
+    mute_window_samples : int
+        Width of the cosine taper applied around each saturated stretch when
+        *saturation_file* is set.  Must match the value used during detection so the
+        stored intervals and the muting agree.  Default 7.
 
     Returns
     -------
@@ -1392,6 +1416,8 @@ def resample_denoise_lfp_cbin(
                 car,
                 str(car_path) if car else None,
                 cadzow_kwargs,
+                str(saturation_file) if saturation_file is not None else None,
+                mute_window_samples,
             )
         )
 

--- a/src/ibldsp/voltage.py
+++ b/src/ibldsp/voltage.py
@@ -304,12 +304,16 @@ def saturation_samples_to_intervals(
     :param _saturation: np.ndarray: Boolean array with saturation samples set as True
     :return:
     """
-    assert not _saturation[0]
     ind, pol = ibldsp.utils.fronts(_saturation.astype(np.int8))
-    # if the last sample is positive, make sure the interval is closed by providing an even number of events
-    if len(pol) > 0 and pol[-1] == 1:
-        pol = np.r_[pol, -1]
+    # fronts is diff-based, so it misses edges at the array boundaries. If the recording
+    # starts saturated, insert a leading rising edge at sample 0; if it ends saturated,
+    # append a trailing falling edge at the last sample — keeping the events paired.
+    if _saturation[0]:
+        ind = np.r_[0, ind]
+        pol = np.r_[1, pol]
+    if _saturation[-1]:
         ind = np.r_[ind, _saturation.shape[0] - 1]
+        pol = np.r_[pol, -1]
     df_saturation = pd.DataFrame(
         np.c_[ind[::2], ind[1::2]], columns=["start_sample", "stop_sample"]
     )

--- a/src/ibldsp/voltage.py
+++ b/src/ibldsp/voltage.py
@@ -1284,6 +1284,40 @@ def _resample_lfp_chunk(args):
     za.flush()
 
 
+def _warmup_pad_out(
+    highpass_cutoff, fs_out, chunk_size_out=8192, cadzow_window=768, floor=512
+):
+    """Per-chunk warmup padding (output samples) sized to the highpass transient.
+
+    Each chunk discards ``pad`` output samples of filter warmup on each side; that pad
+    must outlast the longest filter transient, which is dominated by the zero-phase
+    highpass. A 3rd-order Butterworth's slowest mode has time constant ``1/(pi*fc)``, so
+    the transient scales as ``~1/highpass_cutoff``; we allow ``3 / highpass_cutoff``
+    seconds (~9 time constants). The result is floored so the default 2 Hz case is
+    unchanged, then snapped up to the smallest value keeping ``chunk_size_out + 2*pad`` a
+    multiple of the Cadzow FFT window.
+
+    Parameters
+    ----------
+    highpass_cutoff : float or None
+        Highpass corner [Hz]; None (no highpass) uses the floor.
+    fs_out : float
+        Output (decimated) sampling rate [Hz].
+    chunk_size_out, cadzow_window, floor : int
+        Chunk size, Cadzow window (768) the total must divide, and minimum pad.
+
+    Returns
+    -------
+    int : warmup padding in output samples.
+    """
+    pad = floor
+    if highpass_cutoff:
+        pad = max(floor, int(np.ceil(3.0 / highpass_cutoff * fs_out)))
+    while (chunk_size_out + 2 * pad) % cadzow_window != 0:
+        pad += 1
+    return pad
+
+
 def resample_denoise_lfp_cbin(
     lf_file: spikeglx.Reader | Path | str,
     q: int = 5,
@@ -1328,8 +1362,9 @@ def resample_denoise_lfp_cbin(
         Keys are forwarded to ``ibldsp.cadzow.cadzow_denoiser`` (e.g. ``rank``, ``niter``,
         ``fmax``, ``nswx``, ``gap_threshold``, ``ppca_k``).  ``n_jobs`` is always forced to 1
         inside each worker; outer-level parallelism is controlled by *n_jobs* above.
-        The chunk window (CHUNK_SIZE_OUT + 2 × PAD_OUT = 9216) is a multiple of the
-        canonical Cadzow FFT window (256 × 3 = 768) by design.  Default None (disabled).
+        The chunk window (CHUNK_SIZE_OUT + 2 × PAD_OUT) is kept a multiple of the canonical
+        Cadzow FFT window (256 × 3 = 768) by design; PAD_OUT scales with the highpass corner
+        (see _warmup_pad_out).  Default None (disabled).
     saturation_file : Path or None
         Path to a ``(ns,)`` boolean ``.npy`` memmap flagging saturated samples at the
         input rate.  When provided, each worker rebuilds a cosine mute taper from its
@@ -1346,11 +1381,8 @@ def resample_denoise_lfp_cbin(
     Path
         Path to the completed output .npy file, shape (ns // q, nc).
     """
-    # 9216 = 12 × 768 — chunk + 2 × pad must stay a multiple of the cadzow window
-    PAD_OUT = 512  # output-samples of filter warmup on each side of every chunk
-    CHUNK_SIZE_OUT = 8192
-    assert (CHUNK_SIZE_OUT + 2 * PAD_OUT) % (256 * 3) == 0, (
-        f"CHUNK_SIZE_OUT {CHUNK_SIZE_OUT} + 2*PAD_OUT {PAD_OUT} must be a multiple of 768"
+    CHUNK_SIZE_OUT = (
+        8192  # chunk + 2 × PAD_OUT must stay a multiple of 768 (cadzow window)
     )
 
     sr = lf_file if isinstance(lf_file, spikeglx.Reader) else spikeglx.Reader(lf_file)
@@ -1372,6 +1404,10 @@ def resample_denoise_lfp_cbin(
     geom_x = np.array(geo["x"][:nc]) if geo is not None else None
     geom_y = np.array(geo["y"][:nc]) if geo is not None else None
     fs = float(sr.fs)
+    # Warmup padding scales with the highpass corner (transient ~ 1/highpass_cutoff),
+    # so a lower corner (e.g. 0.5 Hz) automatically gets a longer pad; 2 Hz stays at 512.
+    PAD_OUT = _warmup_pad_out(highpass_cutoff, fs / q, CHUNK_SIZE_OUT)
+    assert (CHUNK_SIZE_OUT + 2 * PAD_OUT) % (256 * 3) == 0
     # Pass raw Reader metadata so workers can reconstruct it for files without a .meta.
     reader_kwargs = {
         "nc": sr.nc,

--- a/src/ibldsp/voltage.py
+++ b/src/ibldsp/voltage.py
@@ -274,7 +274,8 @@ def saturation(
     Computes
     :param data: [nc, ns]: voltage traces array
     :param max_voltage: maximum value of the voltage: scalar or array of size nc (same units as data)
-    :param v_per_sec: maximum derivative of the voltage in V/s (or units/s)
+    :param v_per_sec: maximum derivative of the voltage in V/s (or units/s); None disables the
+        derivative criterion and detects saturation from the absolute voltage alone (use for LFP)
     :param fs: sampling frequency Hz (defaults to 30kHz)
     :param proportion: 0 < proportion <1  of channels above threshold to consider the sample as saturated (0.2)
     :param mute_window_samples=7: number of samples for the cosine taper applied to the saturation
@@ -282,14 +283,16 @@ def saturation(
         saturation [ns]: boolean array indicating the saturated samples
         mute [ns]: float array indicating the mute function to apply to the data [0-1]
     """
-    # first computes the saturated samples
+    # absolute-voltage criterion: fraction of channels clipping at the ADC rail per sample
     max_voltage = np.atleast_1d(max_voltage)[:, np.newaxis]
-    saturation = np.mean(np.abs(data) > max_voltage * 0.96, axis=0)
-    # then compute the derivative of the voltage saturation
-    n_diff_saturated = np.mean(np.abs(np.diff(data, axis=-1)) / fs >= v_per_sec, axis=0)
-    n_diff_saturated = np.r_[n_diff_saturated, 0]
-    # if either of those reaches more than the proportion of channels labels the sample as saturated
-    saturation = np.logical_or(saturation > proportion, n_diff_saturated > proportion)
+    saturation = np.mean(np.abs(data) > max_voltage * 0.96, axis=0) > proportion
+    # optional derivative criterion: flags abnormally fast voltage swings. It is tuned for the
+    # AP band; on the LFP band normal dynamics exceed it and mislabel clean samples, so pass
+    # v_per_sec=None to rely on the absolute-voltage criterion alone.
+    if v_per_sec is not None:
+        n_diff_saturated = np.mean(np.abs(np.diff(data, axis=-1)) / fs >= v_per_sec, axis=0)
+        n_diff_saturated = np.r_[n_diff_saturated, 0]
+        saturation = np.logical_or(saturation, n_diff_saturated > proportion)
     # apply a cosine taper to the saturation to create a mute function
     win = scipy.signal.windows.cosine(mute_window_samples)
     mute = np.maximum(0, 1 - scipy.signal.convolve(saturation, win, mode="same"))
@@ -350,7 +353,8 @@ def saturation_cbin(
     n_jobs : int, optional
         Number of parallel jobs to use for processing, defaults to 4
     v_per_sec : float, optional
-        Maximum derivative of the voltage in V/s (or units/s), defaults to 1e-8
+        Maximum derivative of the voltage in V/s (or units/s), defaults to 1e-8; None disables
+        the derivative criterion (absolute-voltage detection only, appropriate for the LFP band)
     proportion : float, optional
         Threshold proportion (0-1) of channels that must be above threshold to consider
         a sample as saturated, defaults to 0.2

--- a/src/ibldsp/voltage.py
+++ b/src/ibldsp/voltage.py
@@ -1206,15 +1206,14 @@ def _resample_lfp_chunk(args):
     sr_local = spikeglx.Reader(file_bin, **reader_kwargs)
     raw = sr_local[first_in:last_in, :nc].T.astype(np.float32)  # (nc, L_in)
 
-    # Mute saturated stretches before any filtering so rail-clipped values never enter the
-    # highpass or anti-alias FIR. The cosine taper is rebuilt here from the input-rate
-    # boolean mask (see ibldsp.voltage.saturation) to avoid pickling a full-length array.
+    # Saturated stretches are muted *late* — after Cadzow, on the decimated output (see below).
+    # Muting the raw traces before the highpass/CAR/decimate/Cadzow does not keep the muted
+    # span clean: those stages leak energy back into it (visible as residual noise and spurious
+    # CSD sources/sinks). A single re-mute of the final decimated output is both cleaner and
+    # cheaper. The raw-rate boolean mask is loaded here and downsampled to the output grid.
     if saturation_file is not None:
         sat = np.load(saturation_file, mmap_mode="r")
-        sat_slice = np.asarray(sat[first_in:last_in], dtype=np.float64)
-        win = scipy.signal.windows.cosine(mute_window_samples)
-        mute = np.maximum(0.0, 1.0 - scipy.signal.convolve(sat_slice, win, mode="same"))
-        raw = raw * mute[np.newaxis, :].astype(np.float32)
+        sat_slice = np.asarray(sat[first_in:last_in], dtype=bool)
 
     if major_version == 1:
         raw = fourier.fshift(raw, sample_shift, axis=1)
@@ -1282,6 +1281,20 @@ def _resample_lfp_chunk(args):
         # channels from their Cadzow-denoised same-column neighbours to remove it.
         if channel_labels is not None:
             dec = interpolate_bad_channels(dec, channel_labels, cx, cy, groupby_y=True)
+
+    # Late mute: zero the saturated stretches on the final decimated output. The raw-rate mask
+    # is block-max downsampled onto the decimated grid (any saturated raw sample in a q-block
+    # marks its output sample), then cosine-tapered so the mute ramps smoothly. Applied after
+    # Cadzow so no later stage can re-introduce energy into the muted span.
+    if saturation_file is not None:
+        n_dec = dec.shape[1]
+        n_full = n_dec * q
+        if sat_slice.size < n_full:
+            sat_slice = np.r_[sat_slice, np.zeros(n_full - sat_slice.size, dtype=bool)]
+        sat_dec = sat_slice[:n_full].reshape(n_dec, q).any(axis=1).astype(np.float64)
+        win = scipy.signal.windows.cosine(mute_window_samples)
+        mute = np.maximum(0.0, 1.0 - scipy.signal.convolve(sat_dec, win, mode="same"))
+        dec = dec * mute[np.newaxis, :].astype(dec.dtype)
 
     n_out = last_out - first_out
     valid = dec[:, pad_left_out : pad_left_out + n_out]
@@ -1387,14 +1400,15 @@ def resample_denoise_lfp_cbin(
         (see _warmup_pad_out).  Default None (disabled).
     saturation_file : Path or None
         Path to a ``(ns,)`` boolean ``.npy`` memmap flagging saturated samples at the
-        input rate.  When provided, each worker rebuilds a cosine mute taper from its
-        input slice and multiplies the raw traces by it before any processing, so
-        saturated (rail-clipped) values never enter the highpass or anti-alias filters.
+        input rate.  When provided, each worker downsamples its slice of the mask onto the
+        decimated grid and zeroes the saturated stretches on the *final* decimated output —
+        after the highpass, CAR, decimation and Cadzow.  Muting late (rather than the raw
+        traces before filtering) keeps the muted span clean: earlier stages would otherwise
+        leak energy back into it (residual noise and spurious CSD sources/sinks).
         Default None (no muting).
     mute_window_samples : int
-        Width of the cosine taper applied around each saturated stretch when
-        *saturation_file* is set.  Must match the value used during detection so the
-        stored intervals and the muting agree.  Default 7.
+        Width [in decimated output samples] of the cosine taper ramping the mute in and out
+        around each saturated stretch when *saturation_file* is set.  Default 7.
 
     Returns
     -------

--- a/src/ibldsp/voltage.py
+++ b/src/ibldsp/voltage.py
@@ -1220,6 +1220,22 @@ def _resample_lfp_chunk(args):
         raw = fourier.fshift(raw, sample_shift, axis=1)
 
     if highpass_cutoff is not None:
+        # Apodize the true recording boundaries before the highpass. Interior chunks discard
+        # their filter warmup via the PAD_OUT overlap, but the first/last chunk keep the real
+        # recording edge, where the zero-phase highpass rings against the data-boundary step.
+        # Cosine-ramp the raw signal there (~3 filter time-constants, scaling with the corner)
+        # so the filter sees a smooth onset and never generates the transient.
+        taper_len = min(
+            int(np.ceil(3.0 / (2.0 * np.pi * highpass_cutoff) * fs)), last_in - first_in
+        )
+        if taper_len > 1:
+            ramp = utils.fcn_cosine([0, taper_len - 1])(np.arange(taper_len)).astype(
+                np.float32
+            )  # 0 -> 1 cosine
+            if first_in == 0:
+                raw[:, :taper_len] *= ramp
+            if last_in >= sr_local.ns:
+                raw[:, -taper_len:] *= ramp[::-1]
         sos = scipy.signal.butter(
             3, highpass_cutoff, btype="highpass", fs=fs, output="sos"
         )

--- a/src/tests/unit/test_voltage.py
+++ b/src/tests/unit/test_voltage.py
@@ -140,6 +140,24 @@ class TestSaturation(unittest.TestCase):
         self.assertGreater(np.sum(saturated), 5)
         self.assertGreater(np.sum(mute == 0), np.sum(saturated))
 
+    def test_saturation_no_derivative(self):
+        # v_per_sec=None disables the derivative criterion (LFP band): fast but sub-rail
+        # dynamics must NOT be flagged, while true rail clipping still is.
+        np.random.seed(7654)
+        # large, fast fluctuations well below the rail — the derivative criterion would flag
+        # these, the absolute-voltage criterion must not.
+        data = np.random.randn(384, 30_000).astype(np.float32) * 300e-6
+        saturated, _ = ibldsp.voltage.saturation(
+            data, max_voltage=1200e-6, v_per_sec=None
+        )
+        np.testing.assert_array_equal(saturated, 0)
+        # clipping at the rail is still detected without the derivative term
+        data[:, 13_600:13_700] = 1300e-6
+        saturated, _ = ibldsp.voltage.saturation(
+            data, max_voltage=1200e-6, v_per_sec=None
+        )
+        self.assertEqual(np.sum(saturated), 100)
+
     def test_saturation_intervals_output(self):
         saturation = np.zeros(50_000, dtype=bool)
         # we test empty files, make sure we can read/write from empty parquet

--- a/src/tests/unit/test_voltage.py
+++ b/src/tests/unit/test_voltage.py
@@ -265,6 +265,51 @@ class TestLFP(unittest.TestCase):
             diff = d[0:-1:resamp_factor_q, :] - za[:]
             np.testing.assert_array_less(np.abs(diff[1024:-1024] / 1000), 1e-3)
 
+    def test_rsamp_cbin_saturation_mute(self):
+        """A saturation_file mutes the flagged raw samples before filtering: the decimated
+        output over the (tapered) saturated span is attenuated to ~zero, while an
+        unmuted run leaves that span at full amplitude."""
+        ns, nc, fs, q = int(20 * 2500), 8, 2500, 5
+        with tempfile.TemporaryDirectory() as temp_dir:
+            testfile = Path(temp_dir).joinpath("test.dat")
+            sat_file = Path(temp_dir).joinpath("sat.npy")
+            d = np.zeros((ns, nc), dtype=np.float32)
+            for ic in range(nc):
+                d[:, ic] = np.sin(2 * np.pi * (10 + ic * 4) * np.arange(ns) / fs) * 1000
+            d.tofile(testfile)
+            # flag a saturated span well inside the recording (avoid chunk/filter edges)
+            sat = np.zeros(ns, dtype=bool)
+            sat[10 * 2500 : 11 * 2500] = True
+            np.save(sat_file, sat)
+
+            sr = spikeglx.Reader(testfile, ns=ns, nc=nc, fs=fs, dtype=np.float32)
+            out_plain = Path(temp_dir).joinpath("plain.npy")
+            out_muted = Path(temp_dir).joinpath("muted.npy")
+            for out, sf in [(out_plain, None), (out_muted, sat_file)]:
+                ibldsp.voltage.resample_denoise_lfp_cbin(
+                    sr,
+                    output=out,
+                    dtype=np.float32,
+                    highpass_cutoff=None,
+                    car=False,
+                    saturation_file=sf,
+                )
+            za_plain = spikeglx.Reader(
+                out_plain, ns=ns // q, nc=nc, fs=fs / q, dtype=np.float32
+            )[:]
+            za_muted = spikeglx.Reader(
+                out_muted, ns=ns // q, nc=nc, fs=fs / q, dtype=np.float32
+            )[:]
+            # decimated indices of the muted span core (inside the taper)
+            core = slice(int(10.2 * 500), int(10.8 * 500))
+            self.assertLess(np.abs(za_muted[core]).max(), 1.0)  # muted ≈ 0
+            self.assertGreater(
+                np.abs(za_plain[core]).max(), 100.0
+            )  # unmuted full amplitude
+            # outside the saturated span the two runs agree
+            outside = slice(0, int(9.0 * 500))
+            np.testing.assert_allclose(za_muted[outside], za_plain[outside], atol=1e-3)
+
     def test_rsamp_cbin_cadzow_reinterpolation(self):
         """channel_labels + cadzow_kwargs together: the bad channels Cadzow re-estimates
         must be overwritten by an exact per-column linear interpolation of their

--- a/src/tests/unit/test_voltage.py
+++ b/src/tests/unit/test_voltage.py
@@ -315,6 +315,32 @@ class TestLFP(unittest.TestCase):
             diff = d[0:-1:resamp_factor_q, :] - za[:]
             np.testing.assert_array_less(np.abs(diff[1024:-1024] / 1000), 1e-3)
 
+    def test_rsamp_cbin_edge_taper(self):
+        # With a highpass, the true recording start/end are cosine-ramped before filtering so
+        # the zero-phase filter cannot ring against the data-boundary step. The first output
+        # samples must therefore be strongly attenuated relative to steady state.
+        ns = int(60 * 2500)
+        nc = 12
+        fs = 2500
+        with tempfile.TemporaryDirectory() as temp_dir:
+            testfile = Path(temp_dir).joinpath("test.dat")
+            out_file = Path(temp_dir).joinpath("test_rs.npy")
+            t = np.arange(ns) / fs
+            d = np.zeros((ns, nc), dtype=np.float32)
+            for ic in range(nc):
+                # DC offset + low-frequency tone: the highpass would ring at the raw edge
+                d[:, ic] = 500 + 800 * np.sin(2 * np.pi * (5 + ic) * t)
+            with open(testfile, "wb+") as f:
+                d.tofile(f)
+            sr = spikeglx.Reader(testfile, ns=ns, nc=nc, fs=fs, dtype=np.float32)
+            ibldsp.voltage.resample_denoise_lfp_cbin(
+                sr, output=out_file, dtype=np.float32, highpass_cutoff=2.0, car=False
+            )
+            out = np.load(out_file).T  # (nc, ns_out)
+            start = np.sqrt(np.mean(out[:, :5] ** 2))
+            steady = np.sqrt(np.mean(out[:, 2000:4000] ** 2))
+            self.assertLess(start, 0.2 * steady)
+
     def test_rsamp_cbin_saturation_mute(self):
         """A saturation_file mutes the flagged raw samples before filtering: the decimated
         output over the (tapered) saturated span is attenuated to ~zero, while an

--- a/src/tests/unit/test_voltage.py
+++ b/src/tests/unit/test_voltage.py
@@ -158,6 +158,24 @@ class TestSaturation(unittest.TestCase):
         df_sat = ibldsp.voltage.saturation_samples_to_intervals(saturation)
         self.assertEqual(81, np.sum(df_sat["stop_sample"] - df_sat["start_sample"]))
 
+    def test_saturation_intervals_boundary_edges(self):
+        # recordings that start and/or end saturated must not raise (diff-based fronts
+        # misses boundary edges): a leading rising / trailing falling edge is inserted.
+        n = 1000
+        sat = np.zeros(n, dtype=bool)
+        sat[:50] = True  # starts saturated
+        sat[900:] = True  # ends saturated
+        df = ibldsp.voltage.saturation_samples_to_intervals(sat)
+        self.assertEqual(df.shape[0], 2)
+        np.testing.assert_array_equal(df["start_sample"].to_numpy(), [0, 900])
+        np.testing.assert_array_equal(df["stop_sample"].to_numpy(), [50, n - 1])
+        # fully saturated → a single interval spanning the recording
+        df_full = ibldsp.voltage.saturation_samples_to_intervals(np.ones(n, dtype=bool))
+        self.assertEqual(df_full.shape[0], 1)
+        np.testing.assert_array_equal(
+            df_full[["start_sample", "stop_sample"]].to_numpy(), [[0, n - 1]]
+        )
+
 
 class TestInterpolateBadChannels(unittest.TestCase):
     """groupby_y=True: exact per-column linear interpolation along y, ignoring

--- a/src/tests/unit/test_voltage.py
+++ b/src/tests/unit/test_voltage.py
@@ -247,6 +247,20 @@ class TestInterpolateBadChannels(unittest.TestCase):
 
 
 class TestLFP(unittest.TestCase):
+    def test_warmup_pad_out(self):
+        fs_out = 250.0
+        # default 2 Hz corner (and no highpass) keep the historical 512-sample pad
+        self.assertEqual(ibldsp.voltage._warmup_pad_out(2.0, fs_out), 512)
+        self.assertEqual(ibldsp.voltage._warmup_pad_out(None, fs_out), 512)
+        # a lower corner gets a longer pad, covering at least ~3/fc seconds
+        pad_half = ibldsp.voltage._warmup_pad_out(0.5, fs_out)
+        self.assertGreater(pad_half, 512)
+        self.assertGreaterEqual(pad_half / fs_out, 3.0 / 0.5)
+        # the chunk window must always stay a multiple of the 768-sample cadzow window
+        for fc in (None, 0.1, 0.5, 1.0, 2.0, 5.0):
+            pad = ibldsp.voltage._warmup_pad_out(fc, fs_out)
+            self.assertEqual((8192 + 2 * pad) % 768, 0)
+
     def test_rsamp_cbin(self):
         """
         Resamples a binary file by a factor of 5


### PR DESCRIPTION
Saturation-aware and edge-hardening additions to the LFP resampling path, in support of the lfpack codec.

## Changes
- **Muting**: `resample_denoise_lfp_cbin` gains `saturation_file` (raw-rate mask) + `mute_window_samples`. Each worker rebuilds the cosine taper and multiplies raw traces **before** the highpass/anti-alias FIR, so rail-clipped samples never ring into the passband. No-op when `None`.
- **Amplitude-only detection**: `saturation()`'s derivative criterion is opt-out via `v_per_sec=None`. It is tuned for the 30 kHz AP band; at the LFP rate normal dynamics exceed it and mislabel ~23% of clean samples. AP callers keep the `1e-8` default (unchanged).
- **Boundary apodization**: cosine-ramp the raw signal at the true recording start/end (~3 filter time-constants, scaling with the corner) before the highpass, so the zero-phase filter can't ring against the data-boundary step. Interior chunk edges are handled by the warmup padding.
- **Adaptive warmup padding**: per-chunk `PAD_OUT` scales with the highpass corner via `_warmup_pad_out` (~3/corner s, snapped to a 768 multiple). 2 Hz / no-highpass byte-for-byte unchanged.
- **Boundary-edge fix**: `saturation_samples_to_intervals` no longer asserts on a saturated first sample; recordings that start/end saturated get a synthesized edge instead of raising.

## Tests
`test_rsamp_cbin_saturation_mute`, `test_saturation_no_derivative`, `test_rsamp_cbin_edge_taper`, `test_saturation_intervals_boundary_edges`, `test_warmup_pad_out`.
